### PR TITLE
Does not maintain photo orientation

### DIFF
--- a/lib/src/main/java/com/soundcloud/android/crop/CropImageActivity.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/CropImageActivity.java
@@ -155,6 +155,11 @@ public class CropImageActivity extends MonitoredActivity {
         if (sourceUri != null) {
             exifRotation = CropUtil.getExifRotation(FileUtilCrop.getFile(getApplicationContext(), sourceUri));
 
+            CropUtil.copyExifRotation(
+                    CropUtil.getFromMediaUri(this, getContentResolver(), sourceUri),
+                    CropUtil.getFromMediaUri(this, getContentResolver(), saveUri)
+            );
+
             InputStream is = null;
             try {
                 sampleSize = calculateBitmapSampleSize(sourceUri);
@@ -466,10 +471,10 @@ public class CropImageActivity extends MonitoredActivity {
                 CropUtil.closeSilently(outputStream);
             }
 
-            CropUtil.copyExifRotation(
-                    CropUtil.getFromMediaUri(this, getContentResolver(), sourceUri),
-                    CropUtil.getFromMediaUri(this, getContentResolver(), saveUri)
-            );
+//            CropUtil.copyExifRotation(
+//                    CropUtil.getFromMediaUri(this, getContentResolver(), sourceUri),
+//                    CropUtil.getFromMediaUri(this, getContentResolver(), saveUri)
+//            );
 
             setResultUri(saveUri);
         }


### PR DESCRIPTION
Copying the exif data before any change on image file.
If any change is done on image before copy the exif data, it not keeps the orientation data.